### PR TITLE
add droid-hal-version packages to repo

### DIFF
--- a/dhd2modular.sh
+++ b/dhd2modular.sh
@@ -266,6 +266,10 @@ function buildversion() {
       build
     mv -v RPMS/*.rpm $LOCAL_REPO
     cd ../../
+
+    createrepo $LOCAL_REPO
+    sb2 -t $VENDOR-$DEVICE-armv7hl -R -m sdk-install \
+      zypper ref
 }
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
It solves this error:
Info: marking pattern jolla-configuration-mako 1-1 to be installed
Warning: repo problem: nothing provides droid-hal-version-mako needed by pattern:jolla-hw-adaptation-mako-1-1.noarch, 

Error <repo>: found 1 resolver problem, abort!
